### PR TITLE
Add Prometheus metrics for event delivery and Redis latency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -725,6 +725,21 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/@databases/mysql-config/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/@databases/push-to-async-iterable": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@databases/push-to-async-iterable/-/push-to-async-iterable-3.0.0.tgz",
@@ -7989,6 +8004,13 @@
           "requires": {
             "argparse": "^2.0.1"
           }
+        },
+        "typescript": {
+          "version": "5.9.3",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+          "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+          "optional": true,
+          "peer": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "ioredis": "5.2.4",
         "jsonwebtoken": "9.0.0",
         "lodash": "4.17.23",
+        "prom-client": "^15.1.3",
         "ws": "8.19.0"
       },
       "devDependencies": {
@@ -1298,6 +1299,15 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@paralleldrive/cuid2": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
@@ -2475,6 +2485,12 @@
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
       }
+    },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "1.20.4",
@@ -5867,6 +5883,19 @@
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
       "dev": true
     },
+    "node_modules/prom-client": {
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": "^16 || ^18 || >=20"
+      }
+    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -6771,6 +6800,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "license": "MIT",
+      "dependencies": {
+        "bintrees": "1.0.2"
       }
     },
     "node_modules/terser": {
@@ -8421,6 +8459,11 @@
       "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
       "dev": true
     },
+    "@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="
+    },
     "@paralleldrive/cuid2": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
@@ -9416,6 +9459,11 @@
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
       "integrity": "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==",
       "dev": true
+    },
+    "bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw=="
     },
     "body-parser": {
       "version": "1.20.4",
@@ -11890,6 +11938,15 @@
         }
       }
     },
+    "prom-client": {
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "requires": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      }
+    },
     "prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -12515,6 +12572,14 @@
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
       "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
       "dev": true
+    },
+    "tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "requires": {
+        "bintrees": "1.0.2"
+      }
     },
     "terser": {
       "version": "5.46.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "ioredis": "5.2.4",
     "jsonwebtoken": "9.0.0",
     "lodash": "4.17.23",
+    "prom-client": "^15.1.3",
     "ws": "8.19.0"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import {execute, subscribe} from "graphql";
+import {execute, Kind, parse, subscribe, type DocumentNode} from "graphql";
 // @ts-ignore
 import express from "express";
 import {graphqlHTTP} from "express-graphql";
@@ -17,8 +17,65 @@ import {logger} from "./logger";
 import { subscriptionTypeDefs } from "./subscription-schema";
 import { registerSubscriptions } from "./schema-registry";
 import { publishSubscriptionUsage } from "./usage-publisher";
+import {
+    decrementActiveWebsocketConnections,
+    incrementActiveWebsocketConnections,
+    metricsContentType,
+    recordDeliveredEvent,
+    recordHttpRequest,
+    recordSubscriptionStart,
+    recordWebsocketConnection,
+    recordWebsocketError,
+    renderMetrics,
+} from "./metrics";
 
 const app = express();
+const requestStartTimes = new WeakMap<object, bigint>();
+const activeSockets = new WeakSet<object>();
+
+function extractEventNameFromDocument(document: DocumentNode | undefined): string {
+    if (!document?.definitions) {
+        return "unknown";
+    }
+
+    for (const definition of document.definitions) {
+        if (
+            definition.kind !== Kind.OPERATION_DEFINITION ||
+            definition.operation !== "subscription"
+        ) {
+            continue;
+        }
+        const firstSelection = definition.selectionSet.selections[0];
+        if (firstSelection?.kind === Kind.FIELD && firstSelection.name?.value) {
+            return firstSelection.name.value;
+        }
+    }
+
+    return "unknown";
+}
+
+function extractUserId(value: unknown): string {
+    if (!value || typeof value !== "string" || value.trim().length === 0) {
+        return "unknown";
+    }
+    return value;
+}
+
+function parseSubscriptionDocument(query: unknown): DocumentNode | undefined {
+    if (typeof query !== "string" || query.trim().length === 0) {
+        return undefined;
+    }
+
+    try {
+        return parse(query);
+    } catch (_error) {
+        return undefined;
+    }
+}
+
+function getSocketFromContext(ctx: any): object | undefined {
+    return ctx?.extra?.socket;
+}
 
 Sentry.init({
     dsn: config.sentryDsn,
@@ -144,10 +201,36 @@ const schema = makeExecutableSchema({
 });
 
 app.use(Sentry.Handlers.errorHandler());
+app.use((req, res, next) => {
+    requestStartTimes.set(req, process.hrtime.bigint());
+    res.on("finish", () => {
+        const start = requestStartTimes.get(req);
+        if (!start) {
+            return;
+        }
+        requestStartTimes.delete(req);
+
+        const elapsedNanoseconds = Number(process.hrtime.bigint() - start);
+        const durationSeconds = elapsedNanoseconds / 1_000_000_000;
+        const route = req.route?.path || req.path || req.url?.split("?")[0] || "unknown";
+
+        recordHttpRequest({
+            method: req.method,
+            route,
+            statusCode: res.statusCode,
+            durationSeconds,
+        });
+    });
+    next();
+});
 app.use("/graphql", graphqlHTTP({schema}));
 app.use("/", express.static("public"));
 app.get(`/health`, (_, res) => {
     return res.status(200).send("ok");
+});
+app.get("/metrics", async (_req, res) => {
+    res.setHeader("Content-Type", metricsContentType);
+    return res.status(200).send(await renderMetrics());
 });
 
 logger.info("⛲️ Listening on port 8300");
@@ -175,6 +258,7 @@ app.listen(8300, () => {
                     
                     if (!token) {
                         logger.error('WebSocket connection rejected: No authentication token provided in connection params');
+                        recordWebsocketConnection({ status: "rejected", reason: "missing_token" });
                         return false;
                     }
 
@@ -182,17 +266,26 @@ app.listen(8300, () => {
 
                     if (!uid) {
                         logger.error('WebSocket connection rejected: getUserIdByToken returned empty user ID');
+                        recordWebsocketConnection({ status: "rejected", reason: "empty_user_id" });
                         return false;
                     }
 
                     logger.debug('WebSocket connection authenticated', { uid });
                     //@ts-ignore
                     ctx.uid = uid;
+                    recordWebsocketConnection({ status: "accepted", reason: "authenticated" });
+                    incrementActiveWebsocketConnections();
+                    const socket = getSocketFromContext(ctx);
+                    if (socket) {
+                        activeSockets.add(socket);
+                    }
                 } catch (error: any) {
                     logger.errorEnriched('WebSocket connection failed during authentication', error, {
                         hasConnectionParams: !!ctx.connectionParams,
                         hasToken: !!ctx.connectionParams?.token
                     });
+                    recordWebsocketConnection({ status: "error", reason: "auth_error" });
+                    recordWebsocketError({ eventName: "authentication", phase: "connect" });
                     return false;
                 }
             },
@@ -207,6 +300,13 @@ app.listen(8300, () => {
 
             onSubscribe: (ctx, msg) => {
                 const payload: any = (msg as any)?.payload || {};
+                const eventName = extractEventNameFromDocument(parseSubscriptionDocument(payload.query));
+                const userId = extractUserId((ctx as any)?.uid || (ctx as any)?.extra?.uid);
+
+                recordSubscriptionStart({
+                    eventName,
+                    userId,
+                });
                 publishSubscriptionUsage({
                     query: payload.query,
                     operationName: payload.operationName,
@@ -217,13 +317,30 @@ app.listen(8300, () => {
                     logger.errorEnriched("Failed to record onSubscribe usage", error, {
                         operationName: payload.operationName || null,
                     });
+                    recordWebsocketError({ eventName, phase: "subscribe" });
                 });
             },
             onNext: (ctx, msg, args, result) => {
+                const eventName = extractEventNameFromDocument((args as any)?.document as DocumentNode | undefined);
+                const userId = extractUserId((args as any)?.contextValue?.uid || (ctx as any)?.uid || (ctx as any)?.extra?.uid);
+                recordDeliveredEvent({
+                    eventName,
+                    userId,
+                    payload: result,
+                });
                 logger.debug("Next", {ctx, msg, args, result});
             },
             onError: (ctx, msg, errors) => {
+                const eventName = extractEventNameFromDocument(parseSubscriptionDocument((msg as any)?.payload?.query));
+                recordWebsocketError({ eventName, phase: "deliver" });
                 logger.error("Error", {ctx, msg, errors});
+            },
+            onDisconnect: (ctx) => {
+                const socket = getSocketFromContext(ctx);
+                if (socket && activeSockets.has(socket)) {
+                    activeSockets.delete(socket);
+                    decrementActiveWebsocketConnections();
+                }
             },
             onComplete: (ctx, msg) => {
                 logger.debug("Complete", {ctx, msg});

--- a/src/instrument-redis.ts
+++ b/src/instrument-redis.ts
@@ -1,0 +1,55 @@
+import type Redis from "ioredis";
+
+import { recordDataStoreOperation } from "./metrics";
+
+type RedisCommandLike = {
+	name?: string;
+};
+
+function nowInSeconds(): bigint {
+	return process.hrtime.bigint();
+}
+
+function elapsedSeconds(start: bigint): number {
+	return Number(process.hrtime.bigint() - start) / 1_000_000_000;
+}
+
+export function instrumentRedisClient(redis: Redis, clientName: string): Redis {
+	const instrumentedRedis = redis as Redis & { __metricsInstrumented?: boolean };
+	if (instrumentedRedis.__metricsInstrumented) {
+		return redis;
+	}
+
+	const originalSendCommand = redis.sendCommand.bind(redis);
+
+	redis.sendCommand = ((command: RedisCommandLike, stream?: unknown) => {
+		const start = nowInSeconds();
+		const operation = command?.name || "unknown";
+		const result = originalSendCommand(command as any, stream as any);
+
+		return Promise.resolve(result)
+			.then((value) => {
+				recordDataStoreOperation({
+					datastore: "redis",
+					client: clientName,
+					operation,
+					status: "success",
+					durationSeconds: elapsedSeconds(start),
+				});
+				return value;
+			})
+			.catch((error) => {
+				recordDataStoreOperation({
+					datastore: "redis",
+					client: clientName,
+					operation,
+					status: "error",
+					durationSeconds: elapsedSeconds(start),
+				});
+				throw error;
+			});
+	}) as typeof redis.sendCommand;
+
+	instrumentedRedis.__metricsInstrumented = true;
+	return redis;
+}

--- a/src/metrics.test.ts
+++ b/src/metrics.test.ts
@@ -1,0 +1,162 @@
+import {
+	dataStoreOperationDurationSeconds,
+	dataStoreSlowOperationsTotal,
+	eventsDeliveredPayloadBytesTotal,
+	eventsDeliveredTotal,
+	httpRequestsTotal,
+	recordDataStoreOperation,
+	recordDeliveredEvent,
+	recordHttpRequest,
+	recordSubscriptionStart,
+	recordWebsocketConnection,
+	subscriptionStartsTotal,
+	websocketConnectionsTotal,
+} from "./metrics";
+
+describe("metrics", () => {
+	beforeEach(() => {
+		httpRequestsTotal.reset();
+		websocketConnectionsTotal.reset();
+		subscriptionStartsTotal.reset();
+		eventsDeliveredTotal.reset();
+		eventsDeliveredPayloadBytesTotal.reset();
+		dataStoreOperationDurationSeconds.reset();
+		dataStoreSlowOperationsTotal.reset();
+	});
+
+	it("records delivered events with event and user labels", async () => {
+		recordDeliveredEvent({
+			eventName: "onFrameVarroaDetected",
+			userId: "user-1",
+			payload: { data: { onFrameVarroaDetected: { varroaCount: 3 } } },
+		});
+
+		const delivered = await eventsDeliveredTotal.get();
+		expect(delivered.values).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					labels: {
+						event_name: "onFrameVarroaDetected",
+						user_id: "user-1",
+					},
+					value: 1,
+				}),
+			])
+		);
+	});
+
+	it("records payload bytes for delivered events", async () => {
+		recordDeliveredEvent({
+			eventName: "onApiaryUpdated",
+			userId: "user-2",
+			payload: { data: { onApiaryUpdated: { id: "a1" } } },
+		});
+
+		const payloadBytes = await eventsDeliveredPayloadBytesTotal.get();
+		expect(payloadBytes.values).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					labels: {
+						event_name: "onApiaryUpdated",
+					},
+				}),
+			])
+		);
+		const matching = payloadBytes.values.find(
+			(value) => value.labels.event_name === "onApiaryUpdated"
+		);
+		expect(matching?.value).toBeGreaterThan(0);
+	});
+
+	it("normalizes missing labels to unknown", async () => {
+		recordSubscriptionStart({ eventName: "", userId: "" });
+		recordWebsocketConnection({ status: "rejected", reason: "" });
+		recordHttpRequest({
+			method: "get",
+			route: "",
+			statusCode: 200,
+			durationSeconds: 0.01,
+		});
+
+		const subscriptions = await subscriptionStartsTotal.get();
+		const websocketConnections = await websocketConnectionsTotal.get();
+		const httpRequests = await httpRequestsTotal.get();
+
+		expect(subscriptions.values).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					labels: {
+						event_name: "unknown",
+						user_id: "unknown",
+					},
+					value: 1,
+				}),
+			])
+		);
+
+		expect(websocketConnections.values).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					labels: {
+						status: "rejected",
+						reason: "unknown",
+					},
+					value: 1,
+				}),
+			])
+		);
+
+		expect(httpRequests.values).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					labels: {
+						method: "GET",
+						route: "unknown",
+						status_code: "200",
+					},
+					value: 1,
+				}),
+			])
+		);
+	});
+
+	it("records slow data store operations without query parameters", async () => {
+		recordDataStoreOperation({
+			datastore: "redis",
+			client: "usage_publisher",
+			operation: "publish",
+			status: "success",
+			durationSeconds: 0.08,
+		});
+
+		const duration = await dataStoreOperationDurationSeconds.get();
+		const slow = await dataStoreSlowOperationsTotal.get();
+
+		expect(duration.values).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					labels: {
+						datastore: "redis",
+						client: "usage_publisher",
+						operation: "publish",
+						status: "success",
+					},
+				}),
+			])
+		);
+
+		expect(slow.values).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					labels: {
+						datastore: "redis",
+						client: "usage_publisher",
+						operation: "publish",
+						status: "success",
+					},
+					value: 1,
+				}),
+			])
+		);
+	});
+});

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1,0 +1,205 @@
+import * as client from "prom-client";
+
+const register = new client.Registry();
+
+register.setDefaultLabels({
+	service: "event-stream-filter",
+});
+
+client.collectDefaultMetrics({ register });
+
+export const httpRequestDurationSeconds = new client.Histogram({
+	name: "event_stream_filter_http_request_duration_seconds",
+	help: "HTTP request duration in seconds",
+	labelNames: ["method", "route", "status_code"] as const,
+	buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10],
+	registers: [register],
+});
+
+export const httpRequestsTotal = new client.Counter({
+	name: "event_stream_filter_http_requests_total",
+	help: "Total number of HTTP requests",
+	labelNames: ["method", "route", "status_code"] as const,
+	registers: [register],
+});
+
+export const websocketConnectionsTotal = new client.Counter({
+	name: "event_stream_filter_websocket_connections_total",
+	help: "Total number of websocket connection attempts",
+	labelNames: ["status", "reason"] as const,
+	registers: [register],
+});
+
+export const websocketActiveConnections = new client.Gauge({
+	name: "event_stream_filter_websocket_active_connections",
+	help: "Current number of active websocket connections",
+	registers: [register],
+});
+
+export const subscriptionStartsTotal = new client.Counter({
+	name: "event_stream_filter_subscription_starts_total",
+	help: "Total number of subscription start requests",
+	labelNames: ["event_name", "user_id"] as const,
+	registers: [register],
+});
+
+export const eventsDeliveredTotal = new client.Counter({
+	name: "event_stream_filter_events_delivered_total",
+	help: "Total number of subscription events delivered",
+	labelNames: ["event_name", "user_id"] as const,
+	registers: [register],
+});
+
+export const eventsDeliveredPayloadBytesTotal = new client.Counter({
+	name: "event_stream_filter_events_delivered_payload_bytes_total",
+	help: "Total payload bytes delivered through subscriptions",
+	labelNames: ["event_name"] as const,
+	registers: [register],
+});
+
+export const websocketErrorsTotal = new client.Counter({
+	name: "event_stream_filter_websocket_errors_total",
+	help: "Total number of websocket/subscription errors",
+	labelNames: ["event_name", "phase"] as const,
+	registers: [register],
+});
+
+export const dataStoreOperationDurationSeconds = new client.Histogram({
+	name: "event_stream_filter_data_store_operation_duration_seconds",
+	help: "Data store operation duration in seconds",
+	labelNames: ["datastore", "client", "operation", "status"] as const,
+	buckets: [0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 5],
+	registers: [register],
+});
+
+export const dataStoreSlowOperationsTotal = new client.Counter({
+	name: "event_stream_filter_data_store_slow_operations_total",
+	help: "Total number of slow data store operations",
+	labelNames: ["datastore", "client", "operation", "status"] as const,
+	registers: [register],
+});
+
+const SLOW_DATA_STORE_OPERATION_SECONDS = 0.05;
+
+function normalizeLabel(value: string | undefined | null): string {
+	if (!value) {
+		return "unknown";
+	}
+	const normalized = String(value).trim();
+	return normalized.length > 0 ? normalized : "unknown";
+}
+
+export function recordHttpRequest(input: {
+	method: string;
+	route: string;
+	statusCode: number;
+	durationSeconds: number;
+}) {
+	const labels = {
+		method: normalizeLabel(input.method).toUpperCase(),
+		route: normalizeLabel(input.route),
+		status_code: String(input.statusCode),
+	};
+
+	httpRequestsTotal.inc(labels);
+	httpRequestDurationSeconds.observe(labels, input.durationSeconds);
+}
+
+export function recordWebsocketConnection(input: {
+	status: "accepted" | "rejected" | "error";
+	reason: string;
+}) {
+	websocketConnectionsTotal.inc({
+		status: input.status,
+		reason: normalizeLabel(input.reason),
+	});
+}
+
+export function incrementActiveWebsocketConnections() {
+	websocketActiveConnections.inc();
+}
+
+export function decrementActiveWebsocketConnections() {
+	websocketActiveConnections.dec();
+}
+
+export function recordSubscriptionStart(input: {
+	eventName: string;
+	userId?: string;
+}) {
+	subscriptionStartsTotal.inc({
+		event_name: normalizeLabel(input.eventName),
+		user_id: normalizeLabel(input.userId),
+	});
+}
+
+function estimatePayloadBytes(payload: unknown): number {
+	if (payload === undefined || payload === null) {
+		return 0;
+	}
+
+	try {
+		return Buffer.byteLength(JSON.stringify(payload), "utf8");
+	} catch (_error) {
+		return 0;
+	}
+}
+
+export function recordDeliveredEvent(input: {
+	eventName: string;
+	userId?: string;
+	payload?: unknown;
+}) {
+	const eventName = normalizeLabel(input.eventName);
+	eventsDeliveredTotal.inc({
+		event_name: eventName,
+		user_id: normalizeLabel(input.userId),
+	});
+
+	const payloadSize = estimatePayloadBytes(input.payload);
+	if (payloadSize > 0) {
+		eventsDeliveredPayloadBytesTotal.inc(
+			{
+				event_name: eventName,
+			},
+			payloadSize
+		);
+	}
+}
+
+export function recordWebsocketError(input: {
+	eventName?: string;
+	phase: "subscribe" | "deliver" | "connect";
+}) {
+	websocketErrorsTotal.inc({
+		event_name: normalizeLabel(input.eventName),
+		phase: input.phase,
+	});
+}
+
+export function recordDataStoreOperation(input: {
+	datastore: "redis";
+	client: string;
+	operation: string;
+	status: "success" | "error";
+	durationSeconds: number;
+}) {
+	const labels = {
+		datastore: input.datastore,
+		client: normalizeLabel(input.client),
+		operation: normalizeLabel(input.operation),
+		status: input.status,
+	};
+
+	dataStoreOperationDurationSeconds.observe(labels, input.durationSeconds);
+
+	if (input.durationSeconds >= SLOW_DATA_STORE_OPERATION_SECONDS) {
+		dataStoreSlowOperationsTotal.inc(labels);
+	}
+}
+
+export async function renderMetrics(): Promise<string> {
+	return register.metrics();
+}
+
+export const metricsContentType = register.contentType;

--- a/src/redisPubSub.ts
+++ b/src/redisPubSub.ts
@@ -1,9 +1,9 @@
 import { RedisPubSub } from "graphql-redis-subscriptions";
 import Redis from "ioredis";
+import { instrumentRedisClient } from "./instrument-redis";
 
-
-const redisPubSub = new RedisPubSub({
-	subscriber: new Redis({
+const subscriber = instrumentRedisClient(
+	new Redis({
 		port: 6379,
 		host: process.env.ENV_ID === "dev" ? "redis" : "127.0.0.1",
 		username: "default",
@@ -17,12 +17,22 @@ const redisPubSub = new RedisPubSub({
 			return Math.min(times * 500, 5000);
 		},
 	}),
-	publisher: new Redis({
+	"pubsub_subscriber"
+);
+
+const publisher = instrumentRedisClient(
+	new Redis({
 		port: 6379,
 		host: process.env.ENV_ID === "dev" ? "redis" :  "127.0.0.1",
 		username: "default",
 		password: "pass",
 	}),
+	"pubsub_publisher"
+);
+
+const redisPubSub = new RedisPubSub({
+	subscriber,
+	publisher,
 });
 
 export default redisPubSub

--- a/src/usage-publisher.ts
+++ b/src/usage-publisher.ts
@@ -1,5 +1,6 @@
 import Redis from "ioredis";
 import { logger } from "./logger";
+import { instrumentRedisClient } from "./instrument-redis";
 
 const REDIS_CHANNEL = process.env.REDIS_QUERIES_CHANNEL || "graphql-queries";
 
@@ -10,7 +11,7 @@ function getPublisher() {
 		return publisher;
 	}
 
-	publisher = new Redis({
+	publisher = instrumentRedisClient(new Redis({
 		port: Number(process.env.REDIS_PORT || 6379),
 		host:
 			process.env.REDIS_HOST ||
@@ -19,7 +20,7 @@ function getPublisher() {
 		password: process.env.REDIS_SECRET || process.env.REDIS_PASSWORD || "pass",
 		lazyConnect: true,
 		maxRetriesPerRequest: 1,
-	});
+	}), "usage_publisher");
 
 	publisher.on("error", (error) => {
 		logger.error("Subscription usage redis publisher error", { error });


### PR DESCRIPTION
## Summary\n- add Prometheus metrics endpoint and instrumentation for HTTP and websocket lifecycle\n- add event delivery metrics including top events/users signal labels\n- add Redis datastore operation latency + slow-operation counters without query params (low-cardinality)\n- add unit tests for metrics behavior\n\n## Validation\n- npm run lint\n- npm test -- --runInBand